### PR TITLE
issue #25893 - open bom window with proper name and params

### DIFF
--- a/resources/client/scripts/dockSendMessage.js
+++ b/resources/client/scripts/dockSendMessage.js
@@ -62,7 +62,6 @@ function initDockSendMessage()
   mainwindow.crmAccountsUpdated.connect(refreshCommentConsole)
   mainwindow.transferOrdersUpdated.connect(refreshCommentConsole);
 
-  // Connect Signals and Slots
   _b1CommentConsole.clicked.connect(refreshCommentConsole);
   _b2CommentConsole.clicked.connect(preferencesCommentConsole);
 
@@ -71,10 +70,9 @@ function initDockSendMessage()
 
   mainwindow["tick()"].connect(refreshCommentConsole);
 
-  // Don't show if no privs
   var act = _dockSendMessage.toggleViewAction();
   if (!privileges.check("viewSendMsgDock"))
-  {  
+  {
     _dockSendMessage.hide();
     act.enabled = false;
   }
@@ -117,16 +115,14 @@ function sHandleButtons()
     if (QMessageBox.information(mainwindow, qsTr("Send Message?"),
                             qsTr("You are trying to Send Message to Yourself."
                               +" Are you sure that you really want to Continue?."),
-           QMessageBox.Yes | QMessageBox.Default, QMessageBox.No | QMessageBox.Escape) == QMessageBox.No)
+           QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) == QMessageBox.No)
     {
       _usr.clear();
       return;
     }
-    else
-      _send.enabled = (_usr.id() >= 0);
   }
-  else
-    _send.enabled = (_usr.id() >= 0);
+
+  _send.enabled = (_usr.id() >= 0);
 }
 
 function send()
@@ -200,7 +196,7 @@ function fillListCommentConsole()
   }
 
   _commentConsole.clear();
-  
+
   if (cmmntTypeList.length)
     params.commenttype_id = cmmntTypeList;
 
@@ -226,403 +222,156 @@ function populateMenuCommentConsole(pMenu, pItem, pCol)
 {
   try
   {
+    var doctype = pItem.text("comment_source");
+
+    // undo oddities in the desktop-commentConsole mql
+    if (doctype == 'T-Contact')
+      doctype = 'T';
+    else if (doctype == 'OPP-Opportunity')
+      doctype = 'OPP';
+
+    var lookup = {},
+        editAct,
+        viewAct
+    ;
+
+    // TODO: put more detail in the source table then use that instead
+    lookup['ADDR']  = { editPriv: "MaintainAddresses", viewPriv: "ViewAddresses",
+                        id: "addr_id", uiform: "address",                  wflags: Qt.Dialog };
+    lookup['BBH']   = { editPriv: "MaintainBBOMs",     viewPriv: "ViewBBOMs",
+                        id: "bbomhead_id", uiform: "bbom",                     wflags: Qt.Window };
+    lookup['BBI']   = { editPriv: "MaintainBBOMs",     viewPriv: "ViewBBOMs",
+                        id: "bbomitem_id", uiform: "bbomItem",             wflags: Qt.Dialog };
+    lookup['BMH']   = { editPriv: "MaintainBOMs",      viewPriv: "ViewBOMs",
+                        id: "bomhead_id", uiform: "BOM",                   wflags: Qt.Window };
+    lookup['BIM']   = { editPriv: "MaintainBOMs",      viewPriv: "ViewBOMs",
+                        id: "bomitem_id", uiform: "bomItem",               wflags: Qt.Dialog };
+    lookup['BOH']   = { editPriv: "MaintainBOOs",      viewPriv: "ViewBOOs",
+                        id: "boohead_id", uiform: "boo",                      wflags: Qt.Dialog };
+    lookup['BOI']   = { editPriv: "MaintainBOOs",      viewPriv: "ViewBOOs",
+                        id: "booitem_id", uiform: "booItem",               wflags: Qt.Dialog };
+    lookup['CRMA']  = { editPriv: "MaintainPersonalCRMAccounts MaintainAllCRMAccounts",
+                        viewPriv: "ViewPersonalCRMAccounts     ViewAllCRMAccounts",
+                        id: "crmacct_id", uiform: "crmaccount",            wflags: Qt.Window };
+    lookup['T']     = { editPriv: "MaintainPersonalContacts    MaintainAllContacts",
+                        viewPriv: "ViewPersonalContacts        ViewAllContacts",
+                        id: "cntct_id", uiform: "contact",                 wflags: Qt.Dialog };
+    lookup['C']     = { editPriv: "MaintainCustomerMasters", viewPriv: "ViewCustomerMasters",
+                        id: "cust_id", uiform: "customer",                 wflags: Qt.Window };
+    lookup['EMP']   = { editPriv: "MaintainEmployees",       viewPriv: "ViewEmployees",
+                        id: "emp_id", uiform: "employee",                  wflags: Qt.Dialog };
+    lookup['INCDT'] = { editPriv: "MaintainPersonalIncidents   MaintainAllIncidents",
+                        viewPriv: "ViewPersonalIncidents       ViewAllIncidents",
+                        id: "incdt_id", uiform: "incident",                wflags: Qt.Window };
+    lookup['I']     = { editPriv: "MaintainItemMasters",    viewPriv: "ViewItemMasters",
+                        id: "item_id", uiform: "item",                     wflags: Qt.Window };
+    lookup['IS']    = { editPriv: "MaintainItemSites",      viewPriv: "ViewItemSites",
+                        id: "itemsite_id", uiform: "itemSite",             wflags: Qt.Dialog };
+    lookup['IR']    = { editPriv: "MaintainItemSources",    viewPriv: "ViewItemSources",
+                        id: "itemsrc_id", uiform: "itemSource",            wflags: Qt.Dialog };
+    lookup['L']     = { editPriv: "MaintainLocations",      viewPriv: "ViewLocations",
+                        id: "location_id", uiform: "location",             wflags: Qt.Dialog };
+    lookup['LS']    = { editPriv: "",                       viewPriv: "",
+                        id: "ls_id", uiform: "lotSerial",                  wflags: Qt.Dialog };
+    lookup['OPP']   = { editPriv: "MaintainPersonalOpportunities MaintainAllOpportunities",
+                        viewPriv: "ViewPersonalOpportunities     ViewAllOpportunities",
+                        id: "ophead_id", uiform: "opportunity",            wflags: Qt.Dialog };
+    lookup['J']     = { editPriv: "MaintainPersonalProjects      MaintainAllProjects",
+                        viewPriv: "ViewPersonalProjects          ViewAllProjects",
+                        id: "prj_id", uiform: "project",                   wflags: Qt.Dialog };
+    lookup['P']     = { editPriv: "MaintainPurchaseOrders", viewPriv: "ViewPurchaseOrders",
+                        id: "pohead_id", uiform: "purchaseOrder",          wflags: Qt.Window };
+    lookup['PI']    = { editPriv: "MaintainPurchaseOrders", viewPriv: "ViewPurchaseOrders",
+                        id: "poitem_id", uiform: "purchaseOrderItem",      wflags: Qt.Dialog };
+    lookup['RA']    = { editPriv: "MaintainReturns",        viewPriv: "ViewReturns",
+                        id: "rahead_id", uiform: "returnAuthorization",    wflags: Qt.Window };
+    lookup['RI']    = { editPriv: "MaintainReturns",        viewPriv: "ViewReturns",
+                        id: "raitem_id", uiform: "returnAuthorizationItem",wflags: Qt.Dialog };
+    lookup['Q']     = { editPriv: "MaintainQuotes",         viewPriv: "ViewQuotes",
+                        id: "quhead_id", uiform: "salesOrder",             wflags: Qt.Window };
+    lookup['QI']    = { editPriv: "MaintainQuotes",         viewPriv: "ViewQuotes",
+                        id: "soitem_id", uiform: "salesOrderItem",         wflags: Qt.Dialog };
+    lookup['S']     = { editPriv: "MaintainSalesOrders",    viewPriv: "ViewSalesOrders",
+                        id: "sohead_id", uiform: "salesOrder",             wflags: Qt.Window };
+    lookup['SI']    = { editPriv: "MaintainSalesOrders",    viewPriv: "ViewSalesOrders",
+                        id: "soitem_id", uiform: "salesOrderItem",         wflags: Qt.Dialog };
+    lookup['TA']    = { editPriv: "MaintainPersonalProjects  MaintainAllProjects",
+                        viewPriv: "ViewPersonalProjects      ViewAllProjects",
+                        id: "prjtask_id", uiform: "task",                  wflags: Qt.Dialog };
+    lookup['TD']    = { editPriv: "MaintainPersonalToDoItems MaintainAllToDoItems",
+                        viewPriv: "ViewPersonalToDoItems     ViewAllToDoItems",
+                        id: "todoitem_id", uiform: "todoItem",             wflags: Qt.Dialog };
+    lookup['TO']    = { editPriv: "MaintainTransferOrders", viewPriv: "ViewTransferOrders",
+                        id: "tohead_id", uiform: "transferOrder",          wflags: Qt.Window };
+    lookup['TI']    = { editPriv: "MaintainTransferOrders", viewPriv: "ViewTransferOrders",
+                        id: "toitem_id", uiform: "transferOrderItem",      wflags: Qt.Dialog };
+    lookup['V']     = { editPriv: "MaintainVendors",        viewPriv: "ViewVendors",
+                        id: "vend_id", uiform: "vendor",                   wflags: Qt.Window };
+    lookup['WH']    = { editPriv: "MaintainWarehouses",     viewPriv: "ViewWarehouses",
+                        id: "warehous_id", uiform: "warehouse",            wflags: Qt.Dialog };
+    lookup['W']     = { editPriv: "MaintainWorkOrders",     viewPriv: "MaintainWorkOrders",
+                        id: "wo_id", uiform: "workOrder",                  wflags: Qt.Window };
+
     _commentConsole = mainwindow.findChild("_commentConsole");
 
     if(pMenu == null)
       pMenu = _commentConsole.findChild("_menu");
     if(pMenu != null)
     {
-      var tmpact;
-      if(pItem.text(3) == "ADDR")//Address
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Address..."));
-        tmpact.enabled = privileges.check("MaintainAddresses");
-        tmpact.triggered.connect(editaddr);
+      editAct = pMenu.addAction(qsTr("Edit"));
+      editAct.enabled = privileges.check(lookup[doctype].editPriv);
+      editAct.triggered.connect(editDoctype);
 
-        tmpact = pMenu.addAction(qsTr("View Address..."));
-        tmpact.enabled = privileges.check("MaintainAddresses") ||
-                         privileges.check("ViewAddresses");
-        tmpact.triggered.connect(viewaddr);
-      }
-      else if(pItem.text(3) == "BBH")//BBomhead
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Breeder Bill of Material..."));
-        tmpact.enabled = (privileges.check("MaintainBBOMs"));
-        tmpact.triggered.connect(editbbh);
+      viewAct = pMenu.addAction(qsTr("View"));
+      viewAct.enabled = privileges.check(lookup[doctype].editPriv + " " + lookup[doctype].viewPriv);
+      viewAct.triggered.connect(viewDoctype);
+    }
 
-        tmpact = pMenu.addAction(qsTr("View Breeder Bill of Material..."));
-        tmpact.enabled = (privileges.check("MaintainBBOMs") ||
-                          privileges.check("ViewBBOMs"));
-        tmpact.triggered.connect(viewbbh);
-      }
-      else if(pItem.text(3) == "BBI")//BBOMItem
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Breeder Bill of Material Item..."));
-        tmpact.enabled = (privileges.check("MaintainBBOMs"));
-        tmpact.triggered.connect(editbbi);
+    function editDoctype() {
+      var mode = "edit";
+      if (doctype == "Q" || doctype == "QI")
+        mode = "editQuote";
 
-        tmpact = pMenu.addAction(qsTr("View Breeder Bill of Material Item..."));
-        tmpact.enabled = (privileges.check("MaintainBBOMs") ||
-                          privileges.check("ViewBBOMs"));
-        tmpact.triggered.connect(viewbbi);
-      }
-      else if(pItem.text(3) == "BMH")//BOMHead
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Bill of Material..."));
-        tmpact.enabled = (privileges.check("MaintainBOMs"));
-        tmpact.triggered.connect(editbmh);
+      openDoctype(mode);
+    }
 
-        tmpact = pMenu.addAction(qsTr("View Bill of Material..."));
-        tmpact.enabled = (privileges.check("MaintainBOMs") ||
-                          privileges.check("ViewBOMs"));
-        tmpact.triggered.connect(viewbmh);
-      }
-      else if(pItem.text(3) == "BMI")//BOM Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit BOM Item..."));
-        tmpact.enabled = (privileges.check("MaintainBOMs"));
-        tmpact.triggered.connect(editbomitem);
+    function viewDoctype() {
+      var mode = "view";
+      if (doctype == "Q" || doctype == "QI")
+        mode = "viewQuote";
+      openDoctype(mode);
+    }
 
-        tmpact = pMenu.addAction(qsTr("View BOM Item..."));
-        tmpact.enabled = (privileges.check("MaintainBOMs") ||
-                          privileges.check("ViewBOMs"));
-        tmpact.triggered.connect(viewbomitem);
-      }
-      else if(pItem.text(3) == "BOH")//BOO Head
-      {
-        tmpact = pMenu.addAction(qsTr("Edit BOO Head..."));
-        tmpact.enabled = (privileges.check("MaintainBOOs"));
-        tmpact.triggered.connect(editboh);
+    function openDoctype(mode) {
+      try {
+        var params  = { mode: mode },
+            docdesc = lookup[doctype],
+            q;
+        params[docdesc.id] = _commentConsole.id();
 
-        tmpact = pMenu.addAction(qsTr("View BOO Head..."));
-        tmpact.enabled = (privileges.check("MaintainBOOs") ||
-                          privileges.check("ViewBOOs"));
-        tmpact.triggered.connect(viewboh);
-      }
-      else if(pItem.text(3) == "BOI")//BOO Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit BOO Item..."));
-        tmpact.enabled = (privileges.check("MaintainBOOs"));
-        tmpact.triggered.connect(editboi);
+        // BOM window takes an item_id, not a bomhead_id!
+        if (doctype == "BMH") {
+          q = toolbox.executeQuery("SELECT bomhead_item_id FROM bomhead"
+                                 + " WHERE bomhead_id = <? value('bomhead_id') ?>;",
+                                   params);
+          if (q.first()) {
+            params.item_id = q.value("bomhead_item_id");
+          } else if (q.lastError() != QSqlError.NoError) {
+            throw q.lastError().text;
+          }
+        }
 
-        tmpact = pMenu.addAction(qsTr("View BOO Item..."));
-        tmpact.enabled = (privileges.check("MaintainBOOs") ||
-                          privileges.check("ViewBOOs"));
-        tmpact.triggered.connect(viewboi);
-      }
-      else if(pItem.text(3) == "CRMA")//CRMAccount
-      {
-        tmpact = pMenu.addAction(qsTr("Edit CRM Account..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalCRMAccounts") ||
-                          privileges.check("MaintainAllCRMAccounts"));
-        tmpact.triggered.connect(editcrma);
+        var newdlg = toolbox.openWindow(docdesc.uiform, mainwindow,
+                                        (docdesc.wflags == Qt.Dialog) ? Qt.ApplicationModal : Qt.NonModal,
+                                        docdesc.wflags);
+        newdlg.set(params);
+        if (newdlg.exec) {
+          newdlg.exec();
+        }
+      } catch (e) {
+        QMessageBox.critical(mainwindow, "dockSendMessage",
+                             "Could not open a window for source " + doctype + ": " + e);
 
-        tmpact = pMenu.addAction(qsTr("View CRM Account..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalCRMAccounts") ||
-                          privileges.check("ViewPersonalCRMAccounts")||
-                          privileges.check("MaintainPersonalCRMAccounts") ||
-                          privileges.check("ViewAllCRMAccounts"));
-        tmpact.triggered.connect(viewcrma);
-      }
-      else if(pItem.text(3) == "T-Contact")//Contact
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Contact..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalContacts") ||
-                          privileges.check("MaintainAllContacts"));
-        tmpact.triggered.connect(editcntct);
-
-        tmpact = pMenu.addAction(qsTr("View Contact..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalContacts") ||
-                          privileges.check("ViewPersonalContacts")||
-                          privileges.check("MaintainAllContacts") ||
-                          privileges.check("ViewAllContacts"));
-        tmpact.triggered.connect(viewcntct);
-      }
-      else if(pItem.text(3) == "C")//Customer
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Customer..."));
-        tmpact.enabled = (privileges.check("MaintainCustomerMasters"));
-        tmpact.triggered.connect(editcustomer);
-
-        tmpact = pMenu.addAction(qsTr("View Customer..."));
-        tmpact.enabled = (privileges.check("MaintainCustomerMasters") ||
-                          privileges.check("ViewCustomerMasters"));
-        tmpact.triggered.connect(viewcustomer);
-      }
-      else if(pItem.text(3) == "EMP")//Employee
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Employee..."));
-        tmpact.enabled = (privileges.check("MaintainEmployees"));
-        tmpact.triggered.connect(editemp);
-
-        tmpact = pMenu.addAction(qsTr("View Employee..."));
-        tmpact.enabled = (privileges.check("MaintainEmployees") ||
-                          privileges.check("ViewEmployees"));
-        tmpact.triggered.connect(viewemp);
-      }
-      else if(pItem.text(3) == "INCDT")//Incident
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Incident..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalIncidents") ||
-                          privileges.check("MaintainAllIncidents"));
-        tmpact.triggered.connect(editincdt);
-
-        tmpact = pMenu.addAction(qsTr("View Incident..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalIncidents") ||
-                          privileges.check("ViewPersonalIncidents")||
-                          privileges.check("MaintainAllIncidents") ||
-                          privileges.check("ViewAllIncidents"));
-        tmpact.triggered.connect(viewincdt);
-      }
-      else if(pItem.text(3) == "I")//Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Item..."));
-        tmpact.enabled = (privileges.check("MaintainItemMasters"));
-        tmpact.triggered.connect(edititem);
-
-        tmpact = pMenu.addAction(qsTr("View Item..."));
-        tmpact.enabled = (privileges.check("MaintainItemMasters") ||
-                          privileges.check("ViewItemMasters"));
-        tmpact.triggered.connect(viewitem);
-      }
-      else if(pItem.text(3) == "IS")//ItemSite
-      {
-        tmpact = pMenu.addAction(qsTr("Edit ItemSite..."));
-        tmpact.enabled = (privileges.check("MaintainItemSites"));
-        tmpact.triggered.connect(edititemsite);
-
-        tmpact = pMenu.addAction(qsTr("View ItemSite..."));
-        tmpact.enabled = (privileges.check("MaintainItemSites") ||
-                          privileges.check("ViewItemSites"));
-        tmpact.triggered.connect(viewitemsite);
-      }
-      else if(pItem.text(3) == "IR")//ItemSource
-      {
-        tmpact = pMenu.addAction(qsTr("Edit ItemSource..."));
-        tmpact.enabled = (privileges.check("MaintainItemSources"));
-        tmpact.triggered.connect(edititemsource);
-
-        tmpact = pMenu.addAction(qsTr("View ItemSource..."));
-        tmpact.enabled = (privileges.check("MaintainItemSources") ||
-                          privileges.check("ViewItemSources"));
-        tmpact.triggered.connect(viewitemsource);
-      }
-      else if(pItem.text(3) == "L")//Location
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Location..."));
-        tmpact.enabled = (privileges.check("MaintainLocations"));
-        tmpact.triggered.connect(editlocation);
-
-        tmpact = pMenu.addAction(qsTr("View Location..."));
-        tmpact.enabled = (privileges.check("MaintainLocations") ||
-                          privileges.check("ViewLocations"));
-        tmpact.triggered.connect(viewlocation);
-      }
-      else if(pItem.text(3) == "LS")//LotSerial
-      {
-        tmpact = pMenu.addAction(qsTr("Edit LotSerial..."));
-        tmpact.triggered.connect(editlotserial);
-
-        tmpact = pMenu.addAction(qsTr("View LotSerial..."));
-        tmpact.triggered.connect(viewlotserial);
-      }
-      else if(pItem.text(3) == "OPP-Opportunity")//Opportunity
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Opportunity..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalOpportunities") ||
-                          privileges.check("MaintainAllOpportunities"));
-        tmpact.triggered.connect(editopp);
-
-        tmpact = pMenu.addAction(qsTr("View Opportunity..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalOpportunities") ||
-                          privileges.check("ViewPersonalOpportunities")||
-                          privileges.check("MaintainAllOpportunities") ||
-                          privileges.check("ViewAllOpportunities"));
-        tmpact.triggered.connect(viewopp);
-      }
-      else if(pItem.text(3) == "J")//Project
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Project..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalProjects") ||
-                          privileges.check("MaintainAllProjects"));
-        tmpact.triggered.connect(editprj);
-
-        tmpact = pMenu.addAction(qsTr("View Project..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalProjects") ||
-                          privileges.check("ViewPersonalProjects")||
-                          privileges.check("MaintainAllProjects") ||
-                          privileges.check("ViewAllProjects"));
-        tmpact.triggered.connect(viewprj);
-      }
-      else if(pItem.text(3) == "P")//Purchase Order
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Purchase Order..."));
-        tmpact.enabled = (privileges.check("MaintainPurchaseOrders"));
-        tmpact.triggered.connect(editpo);
-
-        tmpact = pMenu.addAction(qsTr("View Purchase Order..."));
-        tmpact.enabled = (privileges.check("MaintainPurchaseOrders") ||
-                          privileges.check("ViewPurchaseOrders"));
-        tmpact.triggered.connect(viewpo);
-      }
-      else if(pItem.text(3) == "PI")//Purchase Order Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Purchase Order Item..."));
-        tmpact.enabled = (privileges.check("MaintainPurchaseOrders"));
-        tmpact.triggered.connect(editpoitem);
-
-        tmpact = pMenu.addAction(qsTr("View Purchase Order Item..."));
-        tmpact.enabled = (privileges.check("MaintainPurchaseOrders") ||
-                          privileges.check("ViewPurchaseOrders"));
-        tmpact.triggered.connect(viewpoitem);
-      }
-      else if(pItem.text(3) == "RA")//Return Authorisation
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Return Authorisation..."));
-        tmpact.enabled = (privileges.check("MaintainReturns"));
-        tmpact.triggered.connect(editreturnauth);
-
-        tmpact = pMenu.addAction(qsTr("View Return Authorisation..."));
-        tmpact.enabled = (privileges.check("MaintainReturns") ||
-                          privileges.check("ViewReturns"));
-        tmpact.triggered.connect(viewreturnauth);
-      }
-      else if(pItem.text(3) == "RI")//Return Authorisation Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Return Authorisation Item..."));
-        tmpact.enabled = (privileges.check("MaintainReturns"));
-        tmpact.triggered.connect(editreturnauthitem);
-
-        tmpact = pMenu.addAction(qsTr("View Return Authorisation Item..."));
-        tmpact.enabled = (privileges.check("MaintainReturns") ||
-                          privileges.check("ViewReturns"));
-        tmpact.triggered.connect(viewreturnauthitem);
-      }
-      else if(pItem.text(3) == "Q")//Quote
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Quote..."));
-        tmpact.enabled = (privileges.check("MaintainQuotes"));
-        tmpact.triggered.connect(editquote);
-
-        tmpact = pMenu.addAction(qsTr("View Quote..."));
-        tmpact.enabled = (privileges.check("MaintainQuotes") ||
-                          privileges.check("ViewQuotes"));
-        tmpact.triggered.connect(viewquote);
-      }
-      else if(pItem.text(3) == "QI")//Quote Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Quote Item..."));
-        tmpact.enabled = (privileges.check("MaintainQuotes"));
-        tmpact.triggered.connect(editquoteitem);
-
-        tmpact = pMenu.addAction(qsTr("View Quote Item..."));
-        tmpact.enabled = (privileges.check("MaintainQuotes") ||
-                          privileges.check("ViewQuotes"));
-        tmpact.triggered.connect(viewquoteitem);
-      }
-      else if(pItem.text(3) == "S")//Sales Order
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Sales Order..."));
-        tmpact.enabled = (privileges.check("MaintainSalesOrders"));
-        tmpact.triggered.connect(editso);
-
-        tmpact = pMenu.addAction(qsTr("View Sales Order..."));
-        tmpact.enabled = (privileges.check("MaintainSalesOrders") ||
-                          privileges.check("ViewSalesOrders"));
-        tmpact.triggered.connect(viewso);
-      }
-      else if(pItem.text(3) == "SI")//Sales Order Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Sales Order Item..."));
-        tmpact.enabled = (privileges.check("MaintainSalesOrders"));
-        tmpact.triggered.connect(editsoitem);
-
-        tmpact = pMenu.addAction(qsTr("View Sales Order Item..."));
-        tmpact.enabled = (privileges.check("MaintainSalesOrders") ||
-                          privileges.check("ViewSalesOrders"));
-        tmpact.triggered.connect(viewsoitem);
-      }
-      else if(pItem.text(3) == "TA")//Task
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Task..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalProjects") ||
-                          privileges.check("MaintainAllProjects"));
-        tmpact.triggered.connect(edittask);
-
-        tmpact = pMenu.addAction(qsTr("View Task..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalProjects") ||
-                          privileges.check("ViewPersonalProjects")||
-                          privileges.check("MaintainAllProjects") ||
-                          privileges.check("ViewAllProjects"));
-        tmpact.triggered.connect(viewtask);
-      }
-      else if(pItem.text(3) == "TD")//TodoItem
-      {
-        tmpact = pMenu.addAction(qsTr("Edit TodoItem..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalToDoItems") ||
-                          privileges.check("MaintainAllToDoItems"));
-        tmpact.triggered.connect(edittodoitem);
-
-        tmpact = pMenu.addAction(qsTr("View TodoItem..."));
-        tmpact.enabled = (privileges.check("MaintainPersonalToDoItems") ||
-                          privileges.check("ViewPersonalToDoItems")||
-                          privileges.check("MaintainAllToDoItems") ||
-                          privileges.check("ViewAllToDoItems"));
-        tmpact.triggered.connect(viewtodoitem);
-      }
-      else if(pItem.text(3) == "TO")//Transfer Order
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Transfer Order..."));
-        tmpact.enabled = (privileges.check("MaintainTransferOrders"));
-        tmpact.triggered.connect(editto);
-
-        tmpact = pMenu.addAction(qsTr("View Transfer Order..."));
-        tmpact.enabled = (privileges.check("MaintainTransferOrders") ||
-                          privileges.check("ViewTransferOrders"));
-        tmpact.triggered.connect(viewto);
-      }
-      else if(pItem.text(3) == "TI")//Transfer Order Item
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Transfer Order Item..."));
-        tmpact.enabled = (privileges.check("MaintainTransferOrders"));
-        tmpact.triggered.connect(edittoitem);
-
-        tmpact = pMenu.addAction(qsTr("View Transfer Order Item..."));
-        tmpact.enabled = (privileges.check("MaintainTransferOrders") ||
-                          privileges.check("ViewTransferOrders"));
-        tmpact.triggered.connect(viewtoitem);
-      }
-      else if(pItem.text(3) == "V")//Vendor
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Vendor..."));
-        tmpact.enabled = (privileges.check("MaintainVendors"));
-        tmpact.triggered.connect(editvend);
-
-        tmpact = pMenu.addAction(qsTr("View Vendor..."));
-        tmpact.enabled = (privileges.check("MaintainVendors") ||
-                          privileges.check("ViewVendors"));
-        tmpact.triggered.connect(viewvend);
-      }
-      else if(pItem.text(3) == "WH")//WareHouse
-      {
-        tmpact = pMenu.addAction(qsTr("Edit WareHouse..."));
-        tmpact.enabled = (privileges.check("MaintainWarehouses"));
-        tmpact.triggered.connect(editwh);
-
-        tmpact = pMenu.addAction(qsTr("View WareHouse..."));
-        tmpact.enabled = (privileges.check("MaintainWarehouses") ||
-                          privileges.check("ViewWarehouses"));
-        tmpact.triggered.connect(viewwh);
-      }
-      else if(pItem.text(3) == "W")//Work Order
-      {
-        tmpact = pMenu.addAction(qsTr("Edit Work Order..."));
-        tmpact.enabled = (privileges.check("MaintainWorkOrders"));
-        tmpact.triggered.connect(editwo);
-
-        tmpact = pMenu.addAction(qsTr("View Work Order..."));
-        tmpact.enabled = (privileges.check("MaintainWorkOrders"));
-        tmpact.triggered.connect(viewwo);
       }
     }
   }
@@ -665,1296 +414,5 @@ function refreshCommentConsole()
   {
     QMessageBox.critical(mainwindow, "dockSendMessage",
                          "refreshCommentConsole exception: " + e);
-  }
-}
-
-function editaddr()
-{
-  try
-  {
-    var params =  new Object();
-    params.addr_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("address", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editaddr exception: " + e);
-  }
-}
-
-function viewaddr()
-{
-  try
-  {
-    var params =  new Object();
-    params.addr_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("address", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewaddr exception: " + e);
-  }
-}
-
-function editbbh()
-{
-  try
-  {
-    var params =  new Object();
-    params.item_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("bbom", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editbbh exception: " + e);
-  }
-}
-
-function viewbbh()
-{
-  try
-  {
-    var params =  new Object();
-    params.item_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("bbom", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewbbh exception: " + e);
-  }
-}
-
-function editbbi()
-{
-  try
-  {
-    var params =  new Object();
-    params.bbomitem_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("bbomItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editbbi exception: " + e);
-  }
-}
-
-function viewbbi()
-{
-  try
-  {
-    var params =  new Object();
-    params.bbomitem_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("bbomItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewbbi exception: " + e);
-  }
-}
-
-function editbmh()
-{
-  try
-  {
-    var params =  new Object();
-    params.item_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("bom", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editbmh exception: " + e);
-  }
-}
-
-function viewbmh()
-{
-  try
-  {
-    var params =  new Object();
-    params.item_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("bom", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewbmh exception: " + e);
-  }
-}
-
-function editbomitem()
-{
-  try
-  {
-    params = new Object;
-    params.bomitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("bomItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editbomitem exception: " + e);
-  }
-}
-
-function viewbomitem()
-{
-  try
-  {
-    params = new Object;
-    params.bomitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("bomItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewbomitem exception: " + e);
-  }
-}
-
-function editboh()
-{
-  try
-  {
-    params = new Object;
-    params.item_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("boo", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editboh exception: " + e);
-  }
-}
-
-function viewboh()
-{
-  try
-  {
-    params = new Object;
-    params.item_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("boo", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewboh exception: " + e);
-  }
-}
-
-function editboi()
-{
-  try
-  {
-    params = new Object;
-    params.booitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("booItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editboi exception: " + e);
-  }
-}
-
-function viewboi()
-{
-  try
-  {
-    params = new Object;
-    params.booitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("booItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewboi exception: " + e);
-  }
-}
-
-function editcntct()
-{
-  try
-  {
-    var params =  new Object();
-    params.cntct_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("contact", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editcntct exception: " + e);
-  }
-}
-
-function viewcntct()
-{
-  try
-  {
-    var params =  new Object();
-    params.cntct_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("contact", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewcntct exception: " + e);
-  }
-}
-
-function editcrma()
-{
-  try
-  {
-    var params =  new Object();
-    params.crmacct_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("crmaccount", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editcrma exception: " + e);
-  }
-}
-
-function viewcrma()
-{
-  try
-  {
-    var params =  new Object();
-    params.crmacct_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("crmaccount", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewcrma exception: " + e);
-  }
-}
-
-function editcustomer()
-{
-  try
-  {
-    var params =  new Object();
-    params.cust_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("customer", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editcustomer exception: " + e);
-  }
-}
-
-function viewcustomer()
-{
-  try
-  {
-    var params =  new Object();
-    params.cust_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("customer", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewcustomer exception: " + e);
-  }
-}
-
-function editemp()
-{
-  try
-  {
-    var params =  new Object();
-    params.emp_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("employee", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editemp exception: " + e);
-  }
-}
-
-function viewemp()
-{
-  try
-  {
-    var params =  new Object();
-    params.emp_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("employee", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewemp exception: " + e);
-  }
-}
-
-function editincdt()
-{
-  try
-  {
-    params = new Object;
-    params.incdt_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("incident", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editincdt exception: " + e);
-  }
-}
-
-function viewincdt()
-{
-  try
-  {
-    var params =  new Object();
-    params.incdt_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("incident", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewincdt exception: " + e);
-  }
-}
-
-function edititem()
-{
-  try
-  {
-    var params =  new Object();
-    params.item_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("item", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "edititem exception: " + e);
-  }
-}
-
-function viewitem()
-{
-  try
-  {
-    var params =  new Object();
-    params.item_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("item", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewitem exception: " + e);
-  }
-}
-
-function edititemsite()
-{
-  try
-  {
-    params = new Object;
-    params.itemsite_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("itemSite", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "edititemsite exception: " + e);
-  }
-}
-
-function viewitemsite()
-{
-  try
-  {
-    params = new Object;
-    params.itemsite_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("itemSite", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewitemsite exception: " + e);
-  }
-}
-
-function edititemsource()
-{
-  try
-  {
-    params = new Object;
-    params.itemsrc_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("itemSource", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "edititemsource exception: " + e);
-  }
-}
-
-function viewitemsource()
-{
-  try
-  {
-    params = new Object;
-    params.itemsrc_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("itemSource", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewitemsource exception: " + e);
-  }
-}
-
-function editlocation()
-{
-  try
-  {
-    var params =  new Object();
-    params.location_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("location", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editlocation exception: " + e);
-  }
-}
-
-function viewlocation()
-{
-  try
-  {
-    var params =  new Object();
-    params.location_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("location", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewlocation exception: " + e);
-  }
-}
-
-function editlotserial()
-{
-  try
-  {
-    var params =  new Object();
-    params.ls_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("lotSerial", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editlotserial exception: " + e);
-  }
-}
-
-function viewlotserial()
-{
-  try
-  {
-    var params =  new Object();
-    params.ls_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("lotSerial", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewlotserial exception: " + e);
-  }
-}
-
-function editopp()
-{
-  try
-  {
-    var params =  new Object();
-    params.ophead_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("opportunity", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editopp exception: " + e);
-  }
-}
-
-function viewopp()
-{
-  try
-  {
-    var params =  new Object();
-    params.ophead_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("opportunity", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewopp exception: " + e);
-  }
-}
-
-function editprj()
-{
-  try
-  {
-    var params =  new Object();
-    params.prj_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("project", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editprj exception: " + e);
-  }
-}
-
-function viewprj()
-{
-  try
-  {
-    var params =  new Object();
-    params.prj_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("project", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewprj exception: " + e);
-  }
-}
-
-function editpo()
-{
-  try
-  {
-    var params =  new Object();
-    params.pohead_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("purchaseOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editpo exception: " + e);
-  }
-}
-
-function viewpo()
-{
-  try
-  {
-    var params =  new Object();
-    params.pohead_id = _commentConsole.id();
-
-    params.mode = "view";
-    var newdlg = toolbox.openWindow("purchaseOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewpo exception: " + e);
-  }
-}
-
-function editpoitem()
-{
-  try
-  {
-    params = new Object;
-    params.poitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("purchaseOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editpoitem exception: " + e);
-  }
-}
-
-function viewpoitem()
-{
-  try
-  {
-    params = new Object;
-    params.poitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("purchaseOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewpoitem exception: " + e);
-  }
-}
-
-function editquote()
-{
-  try
-  {
-    var params =  new Object();
-    params.quhead_id = _commentConsole.id();
-
-    params.mode = "editQuote";
-    var newdlg = toolbox.openWindow("salesOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editquote exception: " + e);
-  }
-}
-
-function viewquote()
-{
-  try
-  {
-    var params =  new Object();
-    params.quhead_id = _commentConsole.id();
-
-    params.mode = "viewQuote";
-    var newdlg = toolbox.openWindow("salesOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewquote exception: " + e);
-  }
-}
-
-function editquoteitem()
-{
-  try
-  {
-    params = new Object;
-    params.soitem_id = _commentConsole.id();
-    params.mode = "editQuote";
-    var newdlg = toolbox.openWindow("salesOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editquoteitem exception: " + e);
-  }
-}
-
-function viewquoteitem()
-{
-  try
-  {
-    params = new Object;
-    params.soitem_id = _commentConsole.id();
-    params.mode = "viewQuote";
-
-    var newdlg = toolbox.openWindow("salesOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewquoteitem exception: " + e);
-  }
-}
-
-function editreturnauth()
-{
-  try
-  {
-    var params =  new Object();
-    params.rahead_id = _commentConsole.id();
-
-    params.mode = "edit";
-    var newdlg = toolbox.openWindow("returnAuthorization", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editreturnauth exception: " + e);
-  }
-}
-
-function viewreturnauth()
-{
-  try
-  {
-    var params =  new Object();
-    params.rahead_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("returnAuthorization", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewreturnauth exception: " + e);
-  }
-}
-
-function editreturnauthitem()
-{
-  try
-  {
-    var params =  new Object();
-    params.raitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("returnAuthorizationItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editreturnauthitem exception: " + e);
-  }
-}
-
-function viewreturnauthitem()
-{
-  try
-  {
-    var params =  new Object();
-    params.raitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("returnAuthorizationItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewreturnauthitem exception: " + e);
-  }
-}
-
-function editso()
-{
-  try
-  {
-    var params =  new Object();
-    params.sohead_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("salesOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editso exception: " + e);
-  }
-}
-
-function viewso()
-{
-  try
-  {
-    var params =  new Object();
-    params.sohead_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("salesOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewso exception: " + e);
-  }
-}
-
-function editsoitem()
-{
-  try
-  {
-    params = new Object;
-    params.soitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("salesOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editsoitem exception: " + e);
-  }
-}
-
-function viewsoitem()
-{
-  try
-  {
-    params = new Object;
-    params.soitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("salesOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewsoitem exception: " + e);
-  }
-}
-
-function edittask()
-{
-  try
-  {
-    params = new Object;
-    params.prjtask_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("task", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "edittask exception: " + e);
-  }
-}
-
-function viewtask()
-{
-  try
-  {
-    params = new Object;
-    params.prjtask_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("task", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewtask exception: " + e);
-  }
-}
-
-function edittodoitem()
-{
-  try
-  {
-    params = new Object;
-    params.todoitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("todoItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "edittodoitem exception: " + e);
-  }
-}
-
-function viewtodoitem()
-{
-  try
-  {
-    params = new Object;
-    params.todoitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("todoItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewtodoitem exception: " + e);
-  }
-}
-
-function editto()
-{
-  try
-  {
-    var params =  new Object();
-    params.tohead_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("transferOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editto exception: " + e);
-  }
-}
-
-function viewto()
-{
-  try
-  {
-    var params =  new Object();
-    params.tohead_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("transferOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewto exception: " + e);
-  }
-}
-
-function edittoitem()
-{
-  try
-  {
-    params = new Object;
-    params.toitem_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("transferOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "edittoitem exception: " + e);
-  }
-}
-
-function viewtoitem()
-{
-  try
-  {
-    params = new Object;
-    params.toitem_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("transferOrderItem", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewtoitem exception: " + e);
-  }
-}
-
-function editvend()
-{
-  try
-  {
-    var params =  new Object();
-    params.vend_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("vendor", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editvend exception: " + e);
-  }
-}
-
-function viewvend()
-{
-  try
-  {
-    var params =  new Object();
-    params.vend_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("vendor", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewvend exception: " + e);
-  }
-}
-
-function editwh()
-{
-  try
-  {
-    params = new Object;
-    params.warehous_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("warehouse", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editwh exception: " + e);
-  }
-}
-
-function viewwh()
-{
-  try
-  {
-    params = new Object;
-    params.warehous_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("warehouse", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    var execval = newdlg.exec();
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewwh exception: " + e);
-  }
-}
-
-function editwo()
-{
-  try
-  {
-    var params =  new Object();
-    params.wo_id = _commentConsole.id();
-    params.mode = "edit";
-
-    var newdlg = toolbox.openWindow("workOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "editwo exception: " + e);
-  }
-}
-
-function viewwo()
-{
-  try
-  {
-    var params =  new Object();
-    params.wo_id = _commentConsole.id();
-    params.mode = "view";
-
-    var newdlg = toolbox.openWindow("workOrder", mainwindow, 0, 1);
-    var tmp = toolbox.lastWindow().set(params);
-    newdlg.exec;
-  }
-  catch (e)
-  {
-    QMessageBox.critical(mainwindow, "dockSendMessage",
-                         "viewwo exception: " + e);
   }
 }

--- a/resources/client/scripts/dockSendMessage.js
+++ b/resources/client/scripts/dockSendMessage.js
@@ -351,11 +351,13 @@ function populateMenuCommentConsole(pMenu, pItem, pCol)
 
         // BOM window takes an item_id, not a bomhead_id!
         if (doctype == "BMH") {
-          q = toolbox.executeQuery("SELECT bomhead_item_id FROM bomhead"
+          q = toolbox.executeQuery("SELECT bomhead_item_id, bomhead_rev_id"
+                                 + "  FROM bomhead"
                                  + " WHERE bomhead_id = <? value('bomhead_id') ?>;",
                                    params);
           if (q.first()) {
             params.item_id = q.value("bomhead_item_id");
+            params.revision_id = q.value("bomhead_rev_id");
           } else if (q.lastError() != QSqlError.NoError) {
             throw q.lastError().text;
           }


### PR DESCRIPTION
Normalize the code for opening documents. That makes it easier to see what the exceptions are. The root bug had two components:

- the old code was opening the non-existent `bom` class with the wrong name (should have been `BOM`)
- the query populating the comment console was getting the bomhead_id but this was being treated as an item_id