### PR TITLE
issue #29841 - fix crash from a script dereferencing null pointer

### DIFF
--- a/resources/client/scripts/initMenu.js
+++ b/resources/client/scripts/initMenu.js
@@ -214,7 +214,7 @@ function addToolBarAction(label, imageName, privilege)
 
     _vToolBarActions.push(act);
 
-    if (!privilege || privileges.check(privilege))
+    if (_mainMenu && (! privilege || privileges.check(privilege)))
       menuItem = new XTreeWidgetItem(_mainMenu, _vToolBarActions.length,
                                      _vToolBarActions.length, label);
   }

--- a/resources/package.xml
+++ b/resources/package.xml
@@ -2,14 +2,14 @@
          name      = "xtdesktop"
          developer = "xTuple"
          descrip   = "xTuple Desktop"
-         version   = "4.0.5"
+         version   = "4.0.6"
          updater   = "2.4.0Beta">
   <pkgnotes>
         xTuple Desktop navigational interface for the xTuple main window.
 
         This package is an extension for xTuple ERP: PostBooks Edition,
         a free and open source Enterprise Resource Planning software suite,
-        Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+        Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
         It is licensed to you under the Common Public Attribution License
         version 1.0, the full text of which (including xTuple-specific Exhibits)
         is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -18,7 +18,7 @@
 
   <prerequisite type="license">
     <message>
-This package is an extension for xTuple ERP: PostBooks Edition, a free and open source Enterprise Resource Planning software suite, Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple. It is licensed to you under the Common Public Attribution License version 1.0, the full text of which (including xTuple-specific Exhibits) is available at www.xtuple.com/CPAL.  By using this software, you agree to be bound by its terms.
+This package is an extension for xTuple ERP: PostBooks Edition, a free and open source Enterprise Resource Planning software suite, Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple. It is licensed to you under the Common Public Attribution License version 1.0, the full text of which (including xTuple-specific Exhibits) is available at www.xtuple.com/CPAL.  By using this software, you agree to be bound by its terms.
      </message>
   </prerequisite>
 


### PR DESCRIPTION
The xtdesktop _mainMenu isn't available when the desktop client is
in workspace mode. The fixed-assets extension was trying to add
to it without checking client mode first.